### PR TITLE
 Improve project display, full sync reliability, and fix TUI bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 # Worktrees
 .worktrees/
 worktrees/
+.claude/settings.local.json

--- a/cmd/ccvault/main.go
+++ b/cmd/ccvault/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/2389-research/ccvault/internal/db"
 	"github.com/2389-research/ccvault/internal/export"
 	"github.com/2389-research/ccvault/internal/mcp"
+	"github.com/2389-research/ccvault/pkg/parser"
 	"github.com/2389-research/ccvault/internal/search"
 	"github.com/2389-research/ccvault/internal/sync"
 	"github.com/2389-research/ccvault/internal/tui"
@@ -397,8 +398,8 @@ Supports Gmail-like query syntax:
 
 		fmt.Printf("Found %d results:\n\n", len(results))
 		for i, r := range results {
-			fmt.Printf("%d. [%s] %s\n", i+1, r.Turn.Type, r.Turn.Timestamp.Format("2006-01-02 15:04"))
-			fmt.Printf("   Project: %s\n", r.ProjectPath)
+			fmt.Printf("%d. [%s] %s  Session: %s\n", i+1, r.Turn.Type, r.Turn.Timestamp.Format("2006-01-02 15:04"), r.Turn.SessionID)
+			fmt.Printf("   Project: %s\n", parser.GetDisplayName(r.ProjectPath))
 			if r.Model != "" {
 				fmt.Printf("   Model: %s\n", r.Model)
 			}
@@ -527,15 +528,24 @@ var listProjectsCmd = &cobra.Command{
 			return nil
 		}
 
-		fmt.Printf("%-50s %8s %10s %12s\n", "PROJECT", "SESSIONS", "TOKENS", "LAST ACTIVE")
-		fmt.Println(strings.Repeat("-", 85))
+		home, _ := os.UserHomeDir()
+
+		fmt.Printf("%-30s %-40s %8s %10s %12s\n", "PROJECT", "PATH", "SESSIONS", "TOKENS", "LAST ACTIVE")
+		fmt.Println(strings.Repeat("-", 105))
 		for _, p := range projects {
 			name := p.DisplayName
-			if len(name) > 48 {
-				name = "..." + name[len(name)-45:]
+			if len(name) > 28 {
+				name = "..." + name[len(name)-25:]
+			}
+			path := p.Path
+			if home != "" && strings.HasPrefix(path, home) {
+				path = "~" + path[len(home):]
+			}
+			if len(path) > 38 {
+				path = "..." + path[len(path)-35:]
 			}
 			lastActive := p.LastActivityAt.Format("2006-01-02")
-			fmt.Printf("%-50s %8d %10s %12s\n", name, p.SessionCount, formatTokens(p.TotalTokens), lastActive)
+			fmt.Printf("%-30s %-40s %8d %10s %12s\n", name, path, p.SessionCount, formatTokens(p.TotalTokens), lastActive)
 		}
 
 		return nil
@@ -605,16 +615,21 @@ var listSessionsCmd = &cobra.Command{
 			return nil
 		}
 
-		fmt.Printf("%-38s %16s %6s %10s %s\n", "SESSION ID", "STARTED", "TURNS", "TOKENS", "MODEL")
-		fmt.Println(strings.Repeat("-", 100))
+		fmt.Printf("%-38s %-25s %16s %6s %10s %s\n", "SESSION ID", "PROJECT", "STARTED", "TURNS", "TOKENS", "MODEL")
+		fmt.Println(strings.Repeat("-", 125))
 		for _, s := range sessions {
+			project := parser.GetDisplayName(s.ProjectPath)
+			if len(project) > 23 {
+				project = "..." + project[len(project)-20:]
+			}
 			model := s.Model
 			if len(model) > 25 {
 				model = model[:22] + "..."
 			}
 			tokens := s.InputTokens + s.OutputTokens
-			fmt.Printf("%-38s %16s %6d %10s %s\n",
+			fmt.Printf("%-38s %-25s %16s %6d %10s %s\n",
 				s.ID,
+				project,
 				s.StartedAt.Format("2006-01-02 15:04"),
 				s.TurnCount,
 				formatTokens(tokens),

--- a/cmd/ccvault/main.go
+++ b/cmd/ccvault/main.go
@@ -16,10 +16,10 @@ import (
 	"github.com/2389-research/ccvault/internal/db"
 	"github.com/2389-research/ccvault/internal/export"
 	"github.com/2389-research/ccvault/internal/mcp"
-	"github.com/2389-research/ccvault/pkg/parser"
 	"github.com/2389-research/ccvault/internal/search"
 	"github.com/2389-research/ccvault/internal/sync"
 	"github.com/2389-research/ccvault/internal/tui"
+	"github.com/2389-research/ccvault/pkg/parser"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -97,6 +97,36 @@ func (db *DB) Close() error {
 	return db.DB.Close()
 }
 
+// ResetAll deletes all data from all tables for a clean full resync
+func (db *DB) ResetAll() error {
+	// Drop FTS triggers and table first to avoid issues with corrupt FTS indexes
+	for _, stmt := range []string{
+		"DROP TRIGGER IF EXISTS turns_ai",
+		"DROP TRIGGER IF EXISTS turns_ad",
+		"DROP TRIGGER IF EXISTS turns_au",
+		"DROP TABLE IF EXISTS turns_fts",
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("drop fts: %w", err)
+		}
+	}
+
+	// Delete data in child-to-parent order
+	tables := []string{"tool_uses", "turns", "sessions", "projects", "source_files"}
+	for _, table := range tables {
+		if _, err := db.Exec("DELETE FROM " + table); err != nil {
+			return fmt.Errorf("delete from %s: %w", table, err)
+		}
+	}
+
+	// Recreate FTS table and triggers via schema init
+	if err := db.init(); err != nil {
+		return fmt.Errorf("reinit schema: %w", err)
+	}
+
+	return nil
+}
+
 // BeginTx starts a new transaction
 func (db *DB) BeginTx() (*sql.Tx, error) {
 	return db.Begin()

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -86,6 +86,14 @@ func (s *Syncer) Run() (*Stats, error) {
 	start := time.Now()
 	stats := &Stats{}
 
+	// Full sync: wipe all data first so stale projects/sessions don't linger
+	if s.full {
+		s.progress("Full sync: clearing existing data...")
+		if err := s.db.ResetAll(); err != nil {
+			return nil, fmt.Errorf("reset database: %w", err)
+		}
+	}
+
 	s.progress("Scanning %s for sessions...", s.claudeHome)
 
 	// Discover session files

--- a/internal/tui/analytics.go
+++ b/internal/tui/analytics.go
@@ -375,9 +375,9 @@ func (m *AnalyticsModel) renderTopProjects() string {
 			name = "..." + name[len(name)-19:]
 		}
 		path := p.ProjectPath
-		if home != "" && strings.HasPrefix(path, home) {
-			path = "~" + path[len(home):]
-		}
+ 		if home != "" && (path == home || strings.HasPrefix(path, home+string(os.PathSeparator))) {
+ 			path = "~" + path[len(home):]
+ 		}
 		if len(path) > 28 {
 			path = "..." + path[len(path)-25:]
 		}

--- a/internal/tui/analytics.go
+++ b/internal/tui/analytics.go
@@ -351,13 +351,15 @@ func (m *AnalyticsModel) renderTopProjects() string {
 		return dimStyle.Render("No project data available")
 	}
 
+	home, _ := os.UserHomeDir()
+
 	var lines []string
 
 	// Header
-	header := fmt.Sprintf("%4s %-38s %8s %12s %12s",
-		"#", "Project", "Sessions", "Tokens", "Last Active")
+	header := fmt.Sprintf("%4s %-24s %-30s %8s %12s %12s",
+		"#", "Project", "Path", "Sessions", "Tokens", "Last Active")
 	lines = append(lines, lipgloss.NewStyle().Bold(true).Render(header))
-	lines = append(lines, strings.Repeat("─", 80))
+	lines = append(lines, strings.Repeat("─", 96))
 
 	// Find max for bar
 	var maxTokens int64
@@ -368,11 +370,22 @@ func (m *AnalyticsModel) renderTopProjects() string {
 	}
 
 	for i, p := range m.topProjects {
-		name := shortenPath(p.ProjectPath, 36)
+		name := filepath.Base(p.ProjectPath)
+		if len(name) > 22 {
+			name = "..." + name[len(name)-19:]
+		}
+		path := p.ProjectPath
+		if home != "" && strings.HasPrefix(path, home) {
+			path = "~" + path[len(home):]
+		}
+		if len(path) > 28 {
+			path = "..." + path[len(path)-25:]
+		}
 		bar := renderBar(p.TotalTokens, maxTokens, 10)
-		row := fmt.Sprintf("%4d %-38s %8d %12s %12s %s",
+		row := fmt.Sprintf("%4d %-24s %-30s %8d %12s %12s %s",
 			i+1,
 			name,
+			path,
 			p.SessionCount,
 			formatCompact(p.TotalTokens),
 			p.LastActive.Format("Jan 02"),

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -5,6 +5,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -204,14 +205,22 @@ func (m *DashboardModel) View() string {
 
 	// Top projects
 	if len(m.topProjects) > 0 {
+		home, _ := os.UserHomeDir()
 		b.WriteString(lipgloss.NewStyle().Bold(true).Render("Recent Projects"))
 		b.WriteString("\n")
 		for _, p := range m.topProjects {
 			name := p.DisplayName
-			if len(name) > 40 {
-				name = "..." + name[len(name)-37:]
+			if len(name) > 22 {
+				name = "..." + name[len(name)-19:]
 			}
-			b.WriteString(normalStyle.Render(fmt.Sprintf("  %-42s %3d sessions", name, p.SessionCount)))
+			path := p.Path
+			if home != "" && strings.HasPrefix(path, home) {
+				path = "~" + path[len(home):]
+			}
+			if len(path) > 35 {
+				path = "..." + path[len(path)-32:]
+			}
+			b.WriteString(normalStyle.Render(fmt.Sprintf("  %-24s %-37s %3d sessions", name, path, p.SessionCount)))
 			b.WriteString("\n")
 		}
 		b.WriteString("\n")

--- a/internal/tui/projects.go
+++ b/internal/tui/projects.go
@@ -5,6 +5,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/2389-research/ccvault/internal/db"
@@ -139,9 +140,11 @@ func (m *ProjectsModel) View() string {
 		b.WriteString("\n")
 	} else {
 		// Header
-		header := fmt.Sprintf("%-50s %8s %10s %12s", "PROJECT", "SESSIONS", "TOKENS", "LAST ACTIVE")
+		header := fmt.Sprintf("%-28s %-38s %8s %10s %12s", "PROJECT", "PATH", "SESSIONS", "TOKENS", "LAST ACTIVE")
 		b.WriteString(headerStyle.Render(header))
 		b.WriteString("\n")
+
+		home, _ := os.UserHomeDir()
 
 		// List
 		visibleRows := m.visibleRows()
@@ -153,13 +156,20 @@ func (m *ProjectsModel) View() string {
 		for i := m.offset; i < end; i++ {
 			p := m.projects[i]
 			name := p.DisplayName
-			if len(name) > 48 {
-				name = "..." + name[len(name)-45:]
+			if len(name) > 26 {
+				name = "..." + name[len(name)-23:]
+			}
+			path := p.Path
+			if home != "" && strings.HasPrefix(path, home) {
+				path = "~" + path[len(home):]
+			}
+			if len(path) > 36 {
+				path = "..." + path[len(path)-33:]
 			}
 			lastActive := p.LastActivityAt.Format("2006-01-02")
 
-			line := fmt.Sprintf("%-50s %8d %10s %12s",
-				name, p.SessionCount, formatTokensPlain(p.TotalTokens), lastActive)
+			line := fmt.Sprintf("%-28s %-38s %8d %10s %12s",
+				name, path, p.SessionCount, formatTokensPlain(p.TotalTokens), lastActive)
 
 			if i == m.cursor {
 				b.WriteString(selectedStyle.Render(line))

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -5,6 +5,7 @@ package tui
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/2389-research/ccvault/internal/db"
@@ -155,13 +156,13 @@ func (m *SearchModel) Update(msg tea.Msg) tea.Cmd {
 				m.ensureVisible()
 			}
 
-		case "home", "g":
+		case "home":
 			if !m.focused && len(m.results) > 0 {
 				m.cursor = 0
 				m.offset = 0
 			}
 
-		case "end", "G":
+		case "end":
 			if !m.focused && len(m.results) > 0 {
 				m.cursor = len(m.results) - 1
 				m.ensureVisible()
@@ -172,6 +173,19 @@ func (m *SearchModel) Update(msg tea.Msg) tea.Cmd {
 				var cmd tea.Cmd
 				m.input, cmd = m.input.Update(msg)
 				return cmd
+			}
+			// vim-style navigation when not typing
+			switch msg.String() {
+			case "g":
+				if len(m.results) > 0 {
+					m.cursor = 0
+					m.offset = 0
+				}
+			case "G":
+				if len(m.results) > 0 {
+					m.cursor = len(m.results) - 1
+					m.ensureVisible()
+				}
 			}
 		}
 
@@ -307,12 +321,7 @@ func (m *SearchModel) View() string {
 					turnType = "asst"
 				}
 
-				project := r.ProjectPath
-				// Show just the last 2 path components
-				parts := strings.Split(project, "/")
-				if len(parts) > 2 {
-					project = strings.Join(parts[len(parts)-2:], "/")
-				}
+				project := filepath.Base(r.ProjectPath)
 				if len(project) > 25 {
 					project = "..." + project[len(project)-22:]
 				}

--- a/internal/tui/sessions.go
+++ b/internal/tui/sessions.go
@@ -5,6 +5,7 @@ package tui
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/2389-research/ccvault/internal/db"
@@ -158,8 +159,14 @@ func (m *SessionsModel) View() string {
 		b.WriteString(normalStyle.Render("No sessions found."))
 		b.WriteString("\n")
 	} else {
-		// Header
-		header := fmt.Sprintf("%-20s %6s %10s %-30s", "STARTED", "TURNS", "TOKENS", "MODEL")
+		// Header - show project column when not filtered to a specific project
+		showProject := m.project == nil
+		var header string
+		if showProject {
+			header = fmt.Sprintf("%-22s %-20s %6s %10s %-30s", "PROJECT", "STARTED", "TURNS", "TOKENS", "MODEL")
+		} else {
+			header = fmt.Sprintf("%-20s %6s %10s %-30s", "STARTED", "TURNS", "TOKENS", "MODEL")
+		}
 		b.WriteString(headerStyle.Render(header))
 		b.WriteString("\n")
 
@@ -178,11 +185,25 @@ func (m *SessionsModel) View() string {
 			}
 			tokens := s.InputTokens + s.OutputTokens
 
-			line := fmt.Sprintf("%-20s %6d %10s %-30s",
-				s.StartedAt.Format("2006-01-02 15:04"),
-				s.TurnCount,
-				formatTokensPlain(tokens),
-				model)
+			var line string
+			if showProject {
+				project := filepath.Base(s.ProjectPath)
+				if len(project) > 20 {
+					project = "..." + project[len(project)-17:]
+				}
+				line = fmt.Sprintf("%-22s %-20s %6d %10s %-30s",
+					project,
+					s.StartedAt.Format("2006-01-02 15:04"),
+					s.TurnCount,
+					formatTokensPlain(tokens),
+					model)
+			} else {
+				line = fmt.Sprintf("%-20s %6d %10s %-30s",
+					s.StartedAt.Format("2006-01-02 15:04"),
+					s.TurnCount,
+					formatTokensPlain(tokens),
+					model)
+			}
 
 			if i == m.cursor {
 				b.WriteString(selectedStyle.Render(line))

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -124,7 +124,7 @@ func TestParseTimestamp(t *testing.T) {
 
 func TestParseSessionReader(t *testing.T) {
 	input := `{"type":"file-history-snapshot","messageId":"msg1","snapshot":{}}
-{"uuid":"turn1","sessionId":"session1","type":"user","timestamp":"2026-02-02T20:00:00.000Z","message":{"role":"user","content":"Hello"}}
+{"uuid":"turn1","sessionId":"session1","type":"user","cwd":"/Users/harper/p/my-project","timestamp":"2026-02-02T20:00:00.000Z","message":{"role":"user","content":"Hello"}}
 {"uuid":"turn2","sessionId":"session1","type":"assistant","timestamp":"2026-02-02T20:01:00.000Z","message":{"model":"claude-opus-4-5-20251101","role":"assistant","content":[{"type":"text","text":"Hi there!"}],"usage":{"input_tokens":10,"output_tokens":5}}}`
 
 	turns, session, err := ParseSessionReader(strings.NewReader(input), "/test/session.jsonl")
@@ -154,6 +154,10 @@ func TestParseSessionReader(t *testing.T) {
 
 	if session.SourceFile != "/test/session.jsonl" {
 		t.Errorf("Expected source file /test/session.jsonl, got %s", session.SourceFile)
+	}
+
+	if session.ProjectPath != "/Users/harper/p/my-project" {
+		t.Errorf("Expected project path /Users/harper/p/my-project, got %s", session.ProjectPath)
 	}
 }
 
@@ -271,9 +275,9 @@ func TestGetDisplayName(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"/Users/harper/Public/src/2389/ccvault", "src/2389/ccvault"},
-		{"/short/path", "/short/path"},
-		{"/a/b/c/d/e", "c/d/e"},
+		{"/Users/harper/Public/src/2389/ccvault", "ccvault"},
+		{"/Users/harper/p/canvas-jira-summarizer", "canvas-jira-summarizer"},
+		{"/short/path", "path"},
 	}
 
 	for _, tc := range tests {

--- a/pkg/parser/scanner.go
+++ b/pkg/parser/scanner.go
@@ -144,22 +144,9 @@ func isValidUUID(s string) bool {
 	return true
 }
 
-// GetDisplayName creates a short display name from a project path
+// GetDisplayName returns the last path component as the project name
 func GetDisplayName(projectPath string) string {
-	// Remove home directory prefix
-	home, _ := os.UserHomeDir()
-	if strings.HasPrefix(projectPath, home) {
-		projectPath = "~" + projectPath[len(home):]
-	}
-
-	// Take last 2-3 path components for display
-	parts := strings.Split(projectPath, "/")
-	if len(parts) <= 3 {
-		return projectPath
-	}
-
-	// Return last 3 components
-	return strings.Join(parts[len(parts)-3:], "/")
+	return filepath.Base(projectPath)
 }
 
 // ScanHistory reads the global history.jsonl file


### PR DESCRIPTION
Display improvements across CLI and TUI

- list-projects: added PATH column with ~ home substitution
- list-sessions: added PROJECT name column
- search: shows project name instead of truncated path, includes session ID
- TUI browse projects: added PATH column with ~ substitution
- TUI recent sessions: shows PROJECT column when not filtered to a single project
- TUI dashboard recent projects: shows both project name and ~/ path
- TUI analytics top projects: shows both project name and ~/ path
- TUI search results: shows project name instead of truncated path

Full sync reliability

- `--full` sync wipes all tables before rebuilding, preventing stale/duplicate project entries
- Drops and recreates FTS5 table/triggers during reset to handle corrupt indexes
- Fixes accumulating session_count/total_tokens inflation on repeated full syncs

Bug fixes

- TUI search: g/G keys no longer swallowed when typing in the search input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full database reset option for full synchronizations (clears and reinitializes data before scanning).

* **Improvements**
  * Added PATH column across projects, analytics, dashboard and sessions listings.
  * Improved path display: tilde (~) for home, truncated paths and shorter project names for consistent table layouts.
  * Sessions and search views show project names/paths more clearly; navigation keys refined.

* **Tests**
  * Parser tests updated to validate project path extraction from session data.

* **Chores**
  * Added .claude/settings.local.json to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->